### PR TITLE
Create 929. Unique Email Addresses.md

### DIFF
--- a/929. Unique Email Addresses.md
+++ b/929. Unique Email Addresses.md
@@ -1,0 +1,138 @@
+
+# 929. Unique Email Addresses
+
+## STEP1
+```text
+何もみずに5分以内に解いてみる
+```
+#### 考えたこと
+```text
+emailsすべてのメールアドレスを1文字ずつ処理
+mapに存在するか確認
+存在してればカウント＋＋
+なければキーとして追加
+@が出てくるまでlocal nameに追加
+local　nameの中で.があれば省く、+があればそこで終わる
+domainのほうはそのまま追加
+```
+
+```cpp
+class Solution {
+public:
+    int numUniqueEmails(vector<string>& emails) {
+        map <string, int> emails_to_count;
+        for (auto email : emails) {
+            string local_name;
+            string domain_name;
+            int i = 0;
+            while (true) {
+                auto push_to_domain_name = [&]() {
+                    while (i < email.size()) {
+                        domain_name.push_back(email[i]);
+                        i++;
+                    }
+                };
+                if (email[i] == '+') {
+                    while (email[i] != '@') {
+                        i++;
+                    }
+                    push_to_domain_name();
+                    break;
+                }
+                if (email[i] == '@') {
+                    push_to_domain_name();
+                    break;
+                }
+                if (email[i] == '.') {
+                    i++;
+                    continue;
+                }
+                local_name.push_back(email[i]);
+                i++;
+            }
+            string local_name_and_domain_name = local_name + domain_name;
+            emails_to_count[local_name_and_domain_name]++;
+        }
+        int unique_emails = emails_to_count.size();
+        return unique_emails;
+    }
+};
+```
+#### 感想
+- 30分くらいかかった
+- 考えたとおりに実装はできたが読みづらい気がする
+- substrを使う手がありそう
+- 想定外入力への対処
+- O(N * K)
+
+## STEP2
+### プルリクやドキュメントを参照
+- @が含まれていないケースへの対処
+- ユーザーがゴミを入力する可能性の考慮
+- emal addressのRFC　https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1
+- rfind https://cpprefjp.github.io/reference/string/basic_string/rfind.html
+- setでできる
+
+```cpp
+class Solution {
+public:
+    int numUniqueEmails(vector<string>& emails) {
+        set <string> unique_emails;
+        for (string& email : emails) {
+            string local_name;
+            string domain_name;
+            auto canonicalize_local_name = [&]() {
+                int plus_position = local_name.find('+');
+                local_name = local_name.substr(0, plus_position);
+                erase(local_name, '.');
+            };
+            auto divide_email_to_local_name_and_domain_name = [&]() {
+                int at_position = email.rfind('@');
+                local_name = email.substr(0, at_position);
+                canonicalize_local_name();
+                domain_name = email.substr(at_position);
+            };
+            divide_email_to_local_name_and_domain_name();
+            string unique_email = local_name + domain_name;
+            unique_emails.insert(unique_email);
+        }
+        int number_of_unique_emails = unique_emails.size();
+        return number_of_unique_emails;
+    }
+};
+```
+
+#### 感想
+- local_nameとdomain_nameに分け、それぞれの処理とその後合わせるところまで明示的になった印象
+- STEP1でもemailはコピーする必要はなかった
+
+## STEP3
+### ミスなく三回書く
+```cpp
+class Solution {
+public:
+    int numUniqueEmails(vector<string>& emails) {
+        set<string> unique_emails;
+        for (string& email : emails) {
+            string local_name;
+            string domain_name;
+            auto canonicalize_local_name = [&]() {
+                int plus_position = local_name.find('+');
+                local_name = local_name.substr(0, plus_position);
+                erase(local_name, '.');
+            };
+            auto divide_email_to_local_name_and_domain_name = [&]() {
+                int at_position = email.rfind('@');
+                local_name = email.substr(0, at_position);
+                canonicalize_local_name();
+                domain_name = email.substr(at_position);
+            };
+            divide_email_to_local_name_and_domain_name();
+            string unique_email = local_name + domain_name;
+            unique_emails.insert(unique_email);
+        }
+        int number_of_unique_emails = unique_emails.size();
+        return number_of_unique_emails;
+    }
+};
+```


### PR DESCRIPTION
[929. Unique Email Addresses](https://leetcode.com/problems/unique-email-addresses/)

問題文
Every valid email consists of a local name and a domain name, separated by the '@' sign. Besides lowercase letters, the email may contain one or more '.' or '+'.

For example, in "alice@leetcode.com", "alice" is the local name, and "leetcode.com" is the domain name.
If you add periods '.' between some characters in the local name part of an email address, mail sent there will be forwarded to the same address without dots in the local name. Note that this rule does not apply to domain names.

For example, "alice.z@leetcode.com" and "alicez@leetcode.com" forward to the same email address.
If you add a plus '+' in the local name, everything after the first plus sign will be ignored. This allows certain emails to be filtered. Note that this rule does not apply to domain names.

For example, "m.y+name@email.com" will be forwarded to "my@email.com".
It is possible to use both of these rules at the same time.

Given an array of strings emails where we send one email to each emails[i], return the number of different addresses that actually receive mails.